### PR TITLE
feat: Enable legacy OpenSSL provider for Node.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "cypress": "cypress open"


### PR DESCRIPTION
Incorporate '--openssl-legacy-provider' flag in 'start' and 'build' scripts to address Node.js compatibility issues with certain packages. This change ensures the project can be built and run smoothly with Node.js versions that lack support for modern OpenSSL providers.